### PR TITLE
Newline is added in SetAlphabet instead

### DIFF
--- a/Assets/ModScripts/ComponentInfo.cs
+++ b/Assets/ModScripts/ComponentInfo.cs
@@ -240,8 +240,6 @@ public class ComponentInfo
             int NumberAmount = Random.Range(0, 2);
             for (int x = 0; x <= LetterAmount; x++)
                 AlphabetKey += Letters[x];
-            if (LetterAmount == 1 && NumberAmount == 1)
-                AlphabetKey += "\n";
             for (int x = 0; x <= NumberAmount; x++)
                 AlphabetKey += Numbers[x];
 
@@ -472,7 +470,7 @@ public class ComponentInfo
         List<string> Names = new List<string>();
 
         for (int i = 0; i < Alphabet.Length; i++)
-            Names.Add(Alphabet[i].Replace(Environment.NewLine, string.Empty));
+            Names.Add(Alphabet[i]);
 
         return Names.Join(", ");
     }

--- a/Assets/ModScripts/CruelModkitScript.cs
+++ b/Assets/ModScripts/CruelModkitScript.cs
@@ -772,7 +772,14 @@ public class CruelModkitScript : MonoBehaviour
     public void SetAlphabet()
     {
         for (int i = 0; i < Alphabet.Length; i++)
-            Alphabet[i].transform.Find("AlphabetText").GetComponentInChildren<TextMesh>().text = Info.Alphabet[i];
+        {
+            string FormattedAlphabetText = Info.Alphabet[i];
+            if (Info.Alphabet[i].Length == 4)
+            {
+                FormattedAlphabetText = Info.Alphabet[i].Insert(2, "\n");
+            }
+            Alphabet[i].transform.Find("AlphabetText").GetComponentInChildren<TextMesh>().text = FormattedAlphabetText;
+        }
     }
 
     public void SetArrows()


### PR DESCRIPTION
The newline is only added to the string right before it's put on the module. This way, the raw info can be accessed much easier through Info.Alphabet without having to worry about filtering out the newline